### PR TITLE
Add Makefile for website tool

### DIFF
--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -1,0 +1,8 @@
+# build the ./website binary
+website : website-upload-tool/main.go
+	cd website-upload-tool; go build -o ../website  main.go 
+
+# clear out ./website binary and public/ (website upload directory)
+clean :
+	-rm website
+	-rm -rf public/*


### PR DESCRIPTION
I copied the Makefile from my [personal website](https://github.com/simon-duchastel/personal-website/blob/main/Makefile) which makes it easy to build the website tool in my github action.