### PR TITLE
Update GET /today ridership estimate to hourly

### DIFF
--- a/backend/mtaSubwayHourlySyncLambda.js
+++ b/backend/mtaSubwayHourlySyncLambda.js
@@ -106,7 +106,7 @@ function ensureFullDayHours(hourlyRidership) {
 // Add daily ridership to each day and add % of daily ridership
 // to each hour
 function populateDailyRidership(hourlyRidership) {
-    for (day in hourlyRidership) {
+    for (const day in hourlyRidership) {
         let dailyTotal = 0;
 
         hourlyRidership[day]["hours"].forEach(hourData => {

--- a/frontend/composeApp/src/commonMain/kotlin/com/duchastel/simon/mtadatavisualizer/data/SubwayDataService.kt
+++ b/frontend/composeApp/src/commonMain/kotlin/com/duchastel/simon/mtadatavisualizer/data/SubwayDataService.kt
@@ -19,7 +19,7 @@ class SubwayDataService(
     }
 ) {
     /**
-     * Returns the current day's ridership
+     * Returns the current day's ridership, or null if there was an error.
      */
     suspend fun getTodaysRidership(): SubwayRidership? {
         val responseBody = client.getAndHandleErrors(SUBWAY_DATA_URL) ?: return null
@@ -68,6 +68,8 @@ class SubwayDataService(
         val estimatedRidershipToday: Int,
         @SerialName("estimated_ridership_so_far")
         val estimatedRidershipSoFar: Int,
+        @SerialName("riders_per_hour")
+        val ridersPerHour: Int,
     )
 
     companion object {

--- a/frontend/composeApp/src/commonMain/kotlin/com/duchastel/simon/mtadatavisualizer/ui/ridershipticker/RidershipTicker.kt
+++ b/frontend/composeApp/src/commonMain/kotlin/com/duchastel/simon/mtadatavisualizer/ui/ridershipticker/RidershipTicker.kt
@@ -16,12 +16,13 @@ fun RidershipTickerScreen() {
     val viewModel: RidershipTickerViewModel = viewModel { RidershipTickerViewModel() }
     val state: RidershipTickerViewModel.State by viewModel.state.collectAsState()
     val ridership = state.ridership
+    val dayOfWeek = state.dayOfWeek
 
     when {
-        ridership != null -> { // success!
-            val ridershipTicker by animateIntAsState(ridership.estimatedRidershipSoFar)
+        ridership != null && dayOfWeek != null -> { // success!
+            val ridershipTicker by animateIntAsState(ridership.numRiders.toInt())
             RidershipTicker(
-                dayOfWeek = ridership.dayOfWeek,
+                dayOfWeek = dayOfWeek,
                 ridership = ridershipTicker,
             )
         }


### PR DESCRIPTION
Update the GET /today endpoint to return the ridership estimate based on more granular hourly ridership data rather than extrapolating daily data linearly. This matters a lot for rush hour, since a much larger percentage of people take the subway during rush hour on weekdays and thus linearly extrapolating daily ridership data for 2am gives a very poor estimate.

Also, add an "riders_per_hour" field to allow the frontend to more accurately estimate per-second ridership based on the estimate of riders in the hour vs. the estimate of riders in the day.

Lastly, the hourly estimates are undercounted because the MTA's data set ([here](https://data.ny.gov/Transportation/MTA-Subway-Hourly-Ridership-Beginning-February-202/wujg-7c2s)) is based on fare payment, whereas their daily data set ([here](https://data.ny.gov/Transportation/MTA-Daily-Ridership-Data-Beginning-2020/vxuj-8kew)) is based on estimates on the train. Upscale the hourly numbers to account for the undercounting, as we consider the overall riders per day from the daily set to be authoritative.