### PR TITLE
Add station breakdown: backend

### DIFF
--- a/backend/mtaSubwayDailyRidershipPerStationToday.js
+++ b/backend/mtaSubwayDailyRidershipPerStationToday.js
@@ -1,4 +1,4 @@
-import { DynamoDBClient, BatchGetItemCommand, GetItemCommand, ScanCommand } from "@aws-sdk/client-dynamodb";
+import { DynamoDBClient, GetItemCommand, ScanCommand } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
 
 // Initialize DynamoDB
@@ -87,7 +87,7 @@ export async function handler(event) {
         const stationData = await dynamodbClient.send(new ScanCommand(scanParams));
 
         const stations = stationData.Items.map(item => ({
-            complexId: item.complex_id.S,
+            complexId: item.id.S,
             complexName: item.name.L[0].S,
         }));
 

--- a/backend/mtaSubwayDailyRidershipPerStationToday.js
+++ b/backend/mtaSubwayDailyRidershipPerStationToday.js
@@ -103,15 +103,16 @@ export async function handler(event) {
         const topStations = [];
         const currentHourKey = `${dayOfWeek}-${numHoursPassed}`;
         for (const station of stations) {
-            const hourlyParams = {
+            const hourlyPerStationParams = {
                 TableName: hourlyPerStationTableName,
                 Key: {
-                    "complex_id": { S: currentHourKey }
+                    "complex_id": { S: currentHourKey },
+                    "ridership": { N: "0" },
                 }
             };
 
             // Get the current hour's data
-            const hourlyData = await dynamodbClient.send(new GetItemCommand(hourlyParams));
+            const hourlyData = await dynamodbClient.send(new GetItemCommand(hourlyPerStationParams));
             const ridersCurrentHour = hourlyData.Item ? parseInt(hourlyData.Item.M.ridership.N) : 0;
 
             // Calculate the estimated ridership so far

--- a/backend/mtaSubwayDailyRidershipPerStationToday.js
+++ b/backend/mtaSubwayDailyRidershipPerStationToday.js
@@ -88,7 +88,7 @@ export async function handler(event) {
 
         const stations = stationData.Items.map(item => ({
             complexId: item.id.S,
-            complexName: item.name.L[0].S,
+            complexName: item.data.L[0].M.name.S,
         }));
 
         // Calculate a scale factor since the hourly ridership is an underestimate

--- a/backend/mtaSubwayDailyRidershipPerStationToday.js
+++ b/backend/mtaSubwayDailyRidershipPerStationToday.js
@@ -1,0 +1,127 @@
+import { DynamoDBClient, GetItemCommand } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
+
+// Initialize DynamoDB
+const dynamodb = new DynamoDBClient({ region: "us-west-2" });
+const dynamodbClient = DynamoDBDocumentClient.from(dynamodb);
+const dailyTableName = 'MTA_Subway_Daily_Ridership';
+const hourlyTableName = 'MTA_Subway_Hourly_Ridership';
+
+// Useful constants
+const timeZoneEST = "America/New_York";
+const secondsPerHour = 60 * 60;
+const hoursPerDay = 24;
+
+// Function to calculate percentage of day passed in EST. Returns a float.
+function calculateDayProgressInEST() {
+    // get the current time and midnight (note this is localized to whatever timezone the
+    // lambda is running in)
+    const now = new Date();
+    const midnight = new Date();
+    midnight.setUTCHours(0, 0, 0, 0);
+
+    // Calculate the elapsed time in ms
+    const totalSecondsInDay = 24 * 60 * 60; // 24hrs x 60min x 60s
+    const offsetMsFromEST = getOffsetFromEST();
+    var elapsedMs = now - midnight;
+
+    // adjust for the EST offest
+    if (elapsedMs < offsetMsFromEST) {
+        // if the elapsed time is less than the offset, then we're in a different day than EST.
+        // we account for that by adding a day hours after subtracting
+        const totalMsInDay = totalSecondsInDay * 1000;
+        elapsedMs += totalMsInDay;
+    }
+    elapsedMs -= offsetMsFromEST;
+    
+    const elapsedSeconds = elapsedMs /= 1000; // convert ms to s
+    return elapsedSeconds / totalSecondsInDay;
+}
+
+function getOffsetFromEST() {
+    const now = new Date();
+    now.setHours(0, 0, 0, 0, 0,)
+    const est = new Date(now.toLocaleString("en-US", { timeZone: timeZoneEST }));
+    return now - est; // difference between current time and EST-normalized in ms
+}
+
+export async function handler() {
+    /**
+     * AWS Lambda handler to retrieve the current day's subway ridership from DynamoDB
+     * and calculate estimated ridership based on the percentage of the day passed.
+     */
+    try {
+        const today = new Date();
+        const dateFormatter = new Intl.DateTimeFormat('en-US', {
+            weekday: "short",
+            timeZone: timeZoneEST,
+        });
+        const dayOfWeek = dateFormatter.format(today);
+
+        // Query daily DynamoDB for today's ridership data
+        const dailyParams = {
+            TableName: dailyTableName,
+            Key: {
+                day_of_week: { S: dayOfWeek }
+            }
+        };
+        const hourlyParams = {
+            TableName: hourlyTableName,
+            Key: {
+                day_of_week: { S: dayOfWeek }
+            }
+        }
+
+        const dailyData = await dynamodbClient.send(new GetItemCommand(dailyParams));
+        const hourlyData = await dynamodbClient.send(new GetItemCommand(hourlyParams));
+
+        // Check if data was found
+        if (!dailyData.Item || !hourlyData.Item) {
+            return {
+                statusCode: 404,
+                body: JSON.stringify({ message: `No data found for ${dayOfWeek}` }),
+            };
+        }
+
+        // Get the daily ridership from DynamoDB
+        const subwayRidership = parseInt(dailyData.Item.subway_ridership.N);
+
+        // Calculate a scale factor since the hourly ridership is an underestimate
+        // and daily ridership isn't
+        const ridershipEstimatedFromHourly = parseInt(hourlyData.Item.daily_ridership.N);
+        const ridershipRatio = subwayRidership / ridershipEstimatedFromHourly;
+
+        // Calculate the estimated ridership so far in the day by adding up the ridership of
+        // each hour that has already passed plus the ridership of the current hour.
+        // Scale by daily ridership factor.
+        const dayProgress = calculateDayProgressInEST();
+        const numHoursPassed = Math.floor(dayProgress * hoursPerDay);
+        const percentOfHourPassed = (dayProgress * hoursPerDay) - numHoursPassed;
+        const hourlyRidership = hourlyData.Item.hourly_ridership.L;
+        let estimatedRidershipSoFar = 0;
+        for (let i = 0; i < numHoursPassed; i++) {
+            estimatedRidershipSoFar += parseInt(hourlyRidership[i].M.ridership.N);
+        }
+        estimatedRidershipSoFar += percentOfHourPassed * parseInt(hourlyRidership[numHoursPassed].M.ridership.N);
+        estimatedRidershipSoFar = Math.floor(estimatedRidershipSoFar * ridershipRatio);
+
+        // Get the hourly ridership per hour for the current hour.
+        // Scale by daily ridership factor.
+        let ridersPerHour = Math.floor(parseInt(hourlyRidership[numHoursPassed].M.ridership.N) * ridershipRatio);
+
+        return {
+            statusCode: 200,
+            body: JSON.stringify({
+                day: dayOfWeek,
+                estimated_ridership_today: subwayRidership,
+                estimated_ridership_so_far: estimatedRidershipSoFar,
+                riders_per_hour: ridersPerHour,
+            }),
+        };
+    } catch (error) {
+        return {
+            statusCode: 500,
+            body: JSON.stringify({ error: `Error fetching data: ${error.message}` }),
+        };
+    }
+}

--- a/backend/mtaSubwayDailyRidershipToday.js
+++ b/backend/mtaSubwayDailyRidershipToday.js
@@ -107,7 +107,7 @@ export async function handler() {
 
         // Get the hourly ridership per hour for the current hour.
         // Scale by daily ridership factor.
-        let ridersPerHour = Math.floor(parseInt(hourlyRidership[numHoursPassed].M.ridership.N) * ridershipRatio);
+        let ridersPerHour = parseInt(hourlyRidership[numHoursPassed].M.ridership.N) * ridershipRatio;
 
         return {
             statusCode: 200,

--- a/backend/mtaSubwayHourlySyncLambda.js
+++ b/backend/mtaSubwayHourlySyncLambda.js
@@ -142,7 +142,8 @@ async function storePerStationData(perStationData) {
         putRequests.push({
             PutRequest: {
                 Item: {
-                    id: dayHourKey,
+                    complex_id: dayHourKey,
+                    ridership: 0,
                     stations: perStationData[dayHourKey].stations
                 }
             }

--- a/backend/mtaSubwayHourlySyncLambda.js
+++ b/backend/mtaSubwayHourlySyncLambda.js
@@ -10,7 +10,7 @@ const perStationTableName = 'MTA_Subway_Hourly_Ridership_Per_Station';
 // Useful constants
 const chunkSize = 1000;
 const MAX_WRITE_ATTEMPTS = 3;
-const WRITE_TIMEOUT_MS = 1000;
+const WRITE_TIMEOUT_MS = 1500;
 const WRITE_BATCH_SIZE = 10;
 
 // MTA Ridership API endpoint

--- a/backend/mtaSubwayHourlySyncLambda.js
+++ b/backend/mtaSubwayHourlySyncLambda.js
@@ -17,7 +17,7 @@ const WRITE_BATCH_SIZE = 10;
 const MTA_API_URL = 'https://data.ny.gov/resource/wujg-7c2s.json';
 
 async function fetchMtaData(offset = 0, limit = chunkSize) {
-    const selectClause = "$select=transit_timestamp,ridership,complex_id";
+    const selectClause = "$select=transit_timestamp,ridership,station_complex_id";
     const whereClause = `$where=transit_mode='subway'`;
     const orderClause = "$order=transit_timestamp DESC";
     const limitClause = `$limit=${limit}&$offset=${offset}`;

--- a/backend/mtaSubwayHourlySyncLambda.js
+++ b/backend/mtaSubwayHourlySyncLambda.js
@@ -142,9 +142,7 @@ async function storePerStationData(perStationData) {
                 putRequests.push({
                     PutRequest: {
                         Item: {
-                            complex_id: complexId,
-                            day_of_week: dayOfWeek,
-                            hour: hour,
+                            complex_id: `${complexId}-${dayOfWeek}-${hour}`,
                             ridership: ridership,
                             percent_of_daily: hours[hour].percent_of_daily,
                         }

--- a/backend/mtaSubwayHourlySyncLambda.js
+++ b/backend/mtaSubwayHourlySyncLambda.js
@@ -10,7 +10,7 @@ const perStationTableName = 'MTA_Subway_Hourly_Ridership_Per_Station';
 // Useful constants
 const chunkSize = 1000;
 const MAX_WRITE_ATTEMPTS = 3;
-const WRITE_TIMEOUT_MS = 1500;
+const WRITE_TIMEOUT_MS = 1000;
 const WRITE_BATCH_SIZE = 10;
 
 // MTA Ridership API endpoint
@@ -32,13 +32,13 @@ async function fetchMtaData(offset = 0, limit = chunkSize) {
 
 async function fetchAndAggregateData() {
     let hourlyRidership = {
-        Sun: { hours: Array(24).fill({ ridership: 0 }) },
-        Mon: { hours: Array(24).fill({ ridership: 0 }) },
-        Tue: { hours: Array(24).fill({ ridership: 0 }) },
-        Wed: { hours: Array(24).fill({ ridership: 0 }) },
-        Thu: { hours: Array(24).fill({ ridership: 0 }) },
-        Fri: { hours: Array(24).fill({ ridership: 0 }) },
-        Sat: { hours: Array(24).fill({ ridership: 0 }) }
+        Sun: { hours: Array.from({ length: 24 }, () => ({ ridership: 0 })) },
+        Mon: { hours: Array.from({ length: 24 }, () => ({ ridership: 0 })) },
+        Tue: { hours: Array.from({ length: 24 }, () => ({ ridership: 0 })) },
+        Wed: { hours: Array.from({ length: 24 }, () => ({ ridership: 0 })) },
+        Thu: { hours: Array.from({ length: 24 }, () => ({ ridership: 0 })) },
+        Fri: { hours: Array.from({ length: 24 }, () => ({ ridership: 0 })) },
+        Sat: { hours: Array.from({ length: 24 }, () => ({ ridership: 0 })) }
     };
     let perStationRidership = {};
     let offset = 0;
@@ -164,7 +164,6 @@ async function storeToDynamoDB(putRequests, tableName) {
         };
 
         let attempt = 0;
-
         while (attempt < MAX_WRITE_ATTEMPTS) {
             try {
                 await dynamodbClient.send(new BatchWriteCommand(batchParams));               

--- a/backend/mtaSubwayHourlySyncLambda.js
+++ b/backend/mtaSubwayHourlySyncLambda.js
@@ -4,16 +4,20 @@ import { DynamoDBDocumentClient, BatchWriteCommand } from "@aws-sdk/lib-dynamodb
 // Initialize DynamoDB
 const dynamodb = new DynamoDBClient({ region: "us-west-2" });
 const dynamodbClient = DynamoDBDocumentClient.from(dynamodb);
-const tableName = 'MTA_Subway_Hourly_Ridership';
+const hourlyTableName = 'MTA_Subway_Hourly_Ridership';
+const perStationTableName = 'MTA_Subway_Hourly_Ridership_Per_Station';
 
-// Useful contstants
+// Useful constants
 const chunkSize = 1000;
+const MAX_WRITE_ATTEMPTS = 3;
+const WRITE_TIMEOUT_MS = 1000;
+const WRITE_BATCH_SIZE = 10;
 
 // MTA Ridership API endpoint
 const MTA_API_URL = 'https://data.ny.gov/resource/wujg-7c2s.json';
 
 async function fetchMtaData(offset = 0, limit = chunkSize) {
-    const selectClause = "$select=transit_timestamp,ridership";
+    const selectClause = "$select=transit_timestamp,ridership,complex_id";
     const whereClause = `$where=transit_mode='subway'`;
     const orderClause = "$order=transit_timestamp DESC";
     const limitClause = `$limit=${limit}&$offset=${offset}`;
@@ -28,22 +32,15 @@ async function fetchMtaData(offset = 0, limit = chunkSize) {
 
 async function fetchAndAggregateData() {
     let hourlyRidership = {
-        Sun: {
-            hours: []
-        }, Mon: {
-            hours: []
-        }, Tue: {
-            hours: []
-        }, Wed: {
-            hours: []
-        }, Thu: {
-            hours: []
-        }, Fri: {
-            hours: []
-        }, Sat: {
-            hours: []
-        } 
+        Sun: { hours: [] },
+        Mon: { hours: [] },
+        Tue: { hours: [] },
+        Wed: { hours: [] },
+        Thu: { hours: [] },
+        Fri: { hours: [] },
+        Sat: { hours: [] }
     };
+    let perStationRidership = {};
     let offset = 0;
     let firstDate = null;
     let chunk;
@@ -53,14 +50,13 @@ async function fetchAndAggregateData() {
     do {
         chunk = await fetchMtaData(offset);
 
-        // If this is the first batch, capture the most recent date (first date)
         if (!firstDate && chunk.length > 0) {
             firstDate = new Date(chunk[0].transit_timestamp);
             lastAllowedDate = new Date(firstDate);
             lastAllowedDate.setDate(firstDate.getDate() - 7);
         }
 
-        hourlyRidership = processChunk(chunk, hourlyRidership, lastAllowedDate);
+        [hourlyRidership, perStationRidership] = processChunk(chunk, hourlyRidership, perStationRidership, lastAllowedDate);
         offset += chunk.length;
 
         lastDateInChunk = new Date(chunk[chunk.length - 1]?.transit_timestamp);
@@ -68,95 +64,130 @@ async function fetchAndAggregateData() {
 
     hourlyRidership = ensureFullDayHours(hourlyRidership);
     hourlyRidership = populateDailyRidership(hourlyRidership);
-    return hourlyRidership;
+    return { hourlyRidership, perStationRidership };
 }
 
-function processChunk(chunk, hourlyRidership, lastAllowedDate) {
+function processChunk(chunk, hourlyRidership, perStationRidership, lastAllowedDate) {
     chunk.forEach(entry => {
         const date = new Date(entry.transit_timestamp);
 
-        // Only process 7 days of data
         if (date >= lastAllowedDate) {
             const dayOfWeek = date.toLocaleString('en-US', { weekday: 'short' });
             const hour = date.getHours();
+            const complexId = entry.complex_id;
 
-            if (!hourlyRidership[dayOfWeek]["hours"][hour]) {
-                hourlyRidership[dayOfWeek]["hours"][hour] = { ridership: 0 };
+            // Populate overall hourly ridership
+            if (!hourlyRidership[dayOfWeek].hours[hour]) {
+                hourlyRidership[dayOfWeek].hours[hour] = { ridership: 0 };
             }
 
-            hourlyRidership[dayOfWeek]["hours"][hour].ridership += parseInt(entry.ridership) || 0;
+            hourlyRidership[dayOfWeek].hours[hour].ridership += parseInt(entry.ridership) || 0;
+
+            // Process per-station ridership
+            if (!perStationRidership[dayOfWeek]) {
+                perStationRidership[dayOfWeek] = { complexId: [] };
+            }
+            if (!perStationRidership[complexId][dayOfWeek]) {
+                perStationRidership[complexId][dayOfWeek] = { hours: Array(24).fill(0) };
+            }
+            perStationRidership[complexId][dayOfWeek].hours[hour] += parseInt(entry.ridership) || 0;
         }
     });
-    return hourlyRidership;
+    return [hourlyRidership, perStationRidership];
 }
 
-// do a pass to ensure that each hour has populated,
-// and set its ridership to 0 if not
 function ensureFullDayHours(hourlyRidership) {
     Object.keys(hourlyRidership).forEach(day => {
         for (let hour = 0; hour < 24; hour++) {
-            if (!hourlyRidership[day]["hours"][hour]) {
-                hourlyRidership[day]["hours"][hour].ridership = 0;
+            if (!hourlyRidership[day].hours[hour]) {
+                hourlyRidership[day].hours[hour] = { ridership: 0 };
             }
         }
     });
     return hourlyRidership;
 }
 
-// Add daily ridership to each day and add % of daily ridership
-// to each hour
 function populateDailyRidership(hourlyRidership) {
     for (const day in hourlyRidership) {
         let dailyTotal = 0;
 
-        hourlyRidership[day]["hours"].forEach(hourData => {
+        hourlyRidership[day].hours.forEach(hourData => {
             dailyTotal += hourData.ridership;
         });
 
-        // add "dailyRidership" for the day
-        // add "percent_of_daily" to each hour
         hourlyRidership[day].dailyRidership = dailyTotal;
-        hourlyRidership[day]["hours"].forEach(hourData => {
+        hourlyRidership[day].hours.forEach(hourData => {
             hourData.percent_of_daily = (hourData.ridership / dailyTotal);
         });
     }
-
     return hourlyRidership;
 }
 
-async function storeToDynamoDB(data) {
-    const putRequests = Object.keys(data).map(dayOfWeek => ({
+async function storeToDynamoDB(data, tableName) {
+    const putRequests = Object.keys(data).map(key => ({
         PutRequest: {
             Item: {
-                day_of_week: dayOfWeek,
-                daily_ridership: data[dayOfWeek].dailyRidership,
-                hourly_ridership: data[dayOfWeek]["hours"],
+                complex_id: key,
+                hourly_ridership: data[key].hours
             }
         }
     }));
 
-    const batchParams = {
+    // batch requests
+    while (putRequests.length > 0) {
+        const batchParams = {
+            RequestItems: {
+                [tableName]: putRequests.splice(0, WRITE_BATCH_SIZE)
+            }
+        };
+
+        let attempt = 0;
+
+        while (attempt < MAX_WRITE_ATTEMPTS) {
+            try {
+                await dynamodbClient.send(new BatchWriteCommand(batchParams));
+                attempt = 0; // reset number of concurrent failed attempts to 0
+                break;
+            } catch (error) {
+                attempt++;
+                console.error(`PUT to dynamo table attempt #${attempt} failed: ${error.message}`);
+
+                if (attempt < MAX_WRITE_ATTEMPTS) {
+                    console.log(`Retrying in ${WRITE_TIMEOUT_MS/1000}s...`);
+                    await new Promise(resolve => setTimeout(resolve, WRITE_TIMEOUT_MS)); // Wait before retrying
+                } else {
+                    throw new Error(`Error storing data in DynamoDB after ${MAX_WRITE_ATTEMPTS} attempts: ${error.message}`);
+                }
+            }
+        }
+    }
+}
+
+async function storeHourlyData(aggregatedData) {
+    const hourlyPutRequests = Object.keys(aggregatedData.hourlyRidership).map(dayOfWeek => ({
+        PutRequest: {
+            Item: {
+                day_of_week: dayOfWeek,
+                daily_ridership: aggregatedData.hourlyRidership[dayOfWeek].dailyRidership,
+                hourly_ridership: aggregatedData.hourlyRidership[dayOfWeek].hours,
+            }
+        }
+    }));
+
+    const hourlyBatchParams = {
         RequestItems: {
-            [tableName]: putRequests
+            [hourlyTableName]: hourlyPutRequests
         }
     };
 
-    try {
-        await dynamodbClient.send(new BatchWriteCommand(batchParams));
-        console.log(`Successfully stored data in ${tableName}`);
-    } catch (error) {
-        throw new Error(`Error storing data in DynamoDB: ${error.message}`);
-    }
+    await storeToDynamoDB(hourlyBatchParams.RequestItems, hourlyTableName);
+    await storeToDynamoDB(aggregatedData.perStationRidership, perStationTableName);
 }
 
 export async function handler() {
     try {
-        // Fetch and aggregate the most recent 7 days of MTA subway ridership data
         const aggregatedData = await fetchAndAggregateData();
-
-        // Store the aggregated data into DynamoDB
-        await storeToDynamoDB(aggregatedData);
-
+        await storeHourlyData(aggregatedData);
         return {
             statusCode: 200,
             body: JSON.stringify('Success: Data stored in DynamoDB')

--- a/backend/mtaSubwayHourlySyncLambda.js
+++ b/backend/mtaSubwayHourlySyncLambda.js
@@ -74,7 +74,7 @@ function processChunk(chunk, hourlyRidership, perStationRidership, lastAllowedDa
         if (date >= lastAllowedDate) {
             const dayOfWeek = date.toLocaleString('en-US', { weekday: 'short' });
             const hour = date.getHours();
-            const complexId = entry.complex_id;
+            const complexId = entry.station_complex_id;
 
             // Populate overall hourly ridership
             hourlyRidership[dayOfWeek].hours[hour].ridership += parseInt(entry.ridership) || 0;


### PR DESCRIPTION
Add the backend to support a per-station breakdown, namely:
- syncing per-station hourly ridership data into the AWS cache
- returning the top 10 most ridden stations with their ridership so that the fronted can display ridership tickers per-station

The frontend will be a separate PR.