### PR TITLE
Add native JS support

### DIFF
--- a/frontend/composeApp/src/jsMain/kotlin/com/duchastel/simon/mtadatavisualizer/main.kt
+++ b/frontend/composeApp/src/jsMain/kotlin/com/duchastel/simon/mtadatavisualizer/main.kt
@@ -1,0 +1,19 @@
+package com.duchastel.simon.mtadatavisualizer
+
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.window.ComposeViewport
+import kotlinx.browser.document
+import org.jetbrains.skiko.wasm.onWasmReady
+
+@OptIn(ExperimentalComposeUiApi::class)
+fun main() {
+    onWasmReady {
+        ComposeViewport(document.body!!) {
+            // by default make everything selectable on web
+            SelectionContainer {
+                App()
+            }
+        }
+    }
+}

--- a/frontend/composeApp/src/jsMain/resources/index.html
+++ b/frontend/composeApp/src/jsMain/resources/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MTA Data Visualizer</title>
+    <link type="text/css" rel="stylesheet" href="styles.css">
+    <script src="skiko.js"></script>
+    <script type="application/javascript" src="composeApp.js"></script>
+</head>
+<body>
+</body>
+</html>

--- a/frontend/composeApp/src/jsMain/resources/styles.css
+++ b/frontend/composeApp/src/jsMain/resources/styles.css
@@ -1,0 +1,7 @@
+html, body {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+}


### PR DESCRIPTION
Safari doesn't have WASM support, so this adds native JS support which is not experimental (see https://slack-chats.kotlinlang.org/t/16766191/hi-i-created-a-simple-web-app-with-kotlin-wasm-using-compose).

Note that there's still some WAS code for some of the rendering, but it's a bit less.

Also, I accidentally pushed a change (https://github.com/simon-duchastel/mta-data-visualizer/commit/36d5b1adba516360df8506739d6ec1fbf7bc7338) with the build.gradle changes as well as a change to make text selectable on web.

## Web text selectable screenshot
https://github.com/simon-duchastel/mta-data-visualizer/commit/36d5b1adba516360df8506739d6ec1fbf7bc7338
![image](https://github.com/user-attachments/assets/594434df-00af-442e-b824-6a946e9b0b2f)
