### PR TITLE
Dedupe station names

### DIFF
--- a/backend/mtaSubwayDailyRidershipPerStationToday.js
+++ b/backend/mtaSubwayDailyRidershipPerStationToday.js
@@ -102,7 +102,7 @@ export async function handler(event) {
 
         const stations = stationData.Items.map(item => ({
             complexId: item.id.S,
-            complexName: item.data.L[0].M.name.S,
+            complexName: item.name.S,
         }));
 
         // Calculate a scale factor since the hourly ridership is an underestimate

--- a/backend/mtaSubwayStationSync.js
+++ b/backend/mtaSubwayStationSync.js
@@ -80,7 +80,7 @@ function groupStations(stations) {
     });
 
     // Update station names if there are duplicates based on name
-    result.forEach(group => {
+    stationsWithName.forEach(group => {
         if (canonicalNameCount[group.name] > 1) {
             group.data.forEach(station => {
                 const routes = station.routes.split(' ').join('/');
@@ -89,7 +89,7 @@ function groupStations(stations) {
         }
     });
 
-    return result;
+    return stationsWithName;
 }
 
 async function storeToDynamoDB(stations) {

--- a/backend/mtaSubwayStationSync.js
+++ b/backend/mtaSubwayStationSync.js
@@ -14,8 +14,8 @@ const WRITE_BATCH_SIZE = 10;
 
 async function fetchStations() {
     // Query for unique stations
-    const selectClause = "$select=complex_id,stop_name,borough,gtfs_latitude,gtfs_longitude";
-    const groupByClause = "$group=complex_id,stop_name,borough,gtfs_latitude,gtfs_longitude";
+    const selectClause = "$select=complex_id,stop_name,borough,gtfs_latitude,gtfs_longitude,daytime_routes";
+    const groupByClause = "$group=complex_id,stop_name,borough,gtfs_latitude,gtfs_longitude,daytime_routes";
     const url = encodeURI(`${DATA_API_URL}?${selectClause}&${groupByClause}`);
 
     const response = await fetch(url);
@@ -55,14 +55,41 @@ function groupStations(stations) {
         // Push the station details into the data array
         grouped[id].data.push({
             name: station.stop_name,
+            routes: station.daytime_routes,
             borough: station.borough,
             latitude: station.gtfs_latitude,
             longitude: station.gtfs_longitude
         });
     });
 
-    // Convert the grouped object to an array
-    return Object.values(grouped);
+    // Convert the grouped object to an array and add canonical names
+    const stationsWithName = Object.values(grouped).map(group => {
+        // Set canonical name for the complex (if there are multiple)
+        const updatedGroup = {
+            ...group,
+            name: group.data[0].name,
+        };
+
+        return updatedGroup;
+    });
+
+    // Count occurrences of canonical names to find duplicates
+    const canonicalNameCount = {};
+    stationsWithName.forEach(group => {
+        canonicalNameCount[group.name] = (canonicalNameCount[group.name] || 0) + 1;
+    });
+
+    // Update station names if there are duplicates based on name
+    result.forEach(group => {
+        if (canonicalNameCount[group.name] > 1) {
+            group.data.forEach(station => {
+                const routes = station.routes.split(' ').join('/');
+                station.name = `${station.name} (${routes})`;
+            });
+        }
+    });
+
+    return result;
 }
 
 async function storeToDynamoDB(stations) {


### PR DESCRIPTION
I noticed that some complexes have the same station name, which makes the UI confusing. Notably, "34th St. Penn Station" is the name for two distinct complexes: the one serving the A/C/E trains, and the one serving the 1/2/3 trains.

This updates the sync lambda to add a canonical "name" field (which is deduped with the daytime trains serving it if there are duplicate names in the whole DB) and also updates the GET /today/stations lambda to pull from the name field instead of defaulting to the first field.