### PR TITLE
Fix JS build

### DIFF
--- a/frontend/composeApp/build.gradle.kts
+++ b/frontend/composeApp/build.gradle.kts
@@ -10,19 +10,20 @@ plugins {
 
 kotlin {
     js {
-        moduleName = "composeApp"
-        binaries.executable()
+        moduleName = "jsComposeApp"
         browser {
             useCommonJs()
             commonWebpackConfig {
                 outputFileName = "$moduleName.js"
             }
         }
+        binaries.executable()
+        useEsModules()
     }
 
     @OptIn(ExperimentalWasmDsl::class)
     wasmJs {
-        moduleName = "composeApp"
+        moduleName = "wasmJsComposeApp"
         browser {
             val rootDirPath = project.rootDir.path
             val projectDirPath = project.projectDir.path
@@ -64,13 +65,6 @@ kotlin {
 
             // Time
             implementation(libs.kotlinx.datetime)
-        }
-
-        val jsMain by getting {
-            dependencies {
-                @Suppress("DEPRECATION")
-                implementation(compose.web.core) // Required for Compose Web/Canvas on JS
-            }
         }
     }
 }

--- a/frontend/gradle.properties
+++ b/frontend/gradle.properties
@@ -7,3 +7,4 @@ org.gradle.jvmargs=-Xmx2048M -Dfile.encoding=UTF-8
 
 #Compose
 org.jetbrains.compose.experimental.jscanvas.enabled=true
+org.jetbrains.compose.experimental.wasm.enabled=true


### PR DESCRIPTION
When I added the JS build in #16, I caused a build error in gradle from the WASM and JS targets having the same module names. Updating this fixed the build issue locally, and I hope that means it fixes it in Github Actions as well.