### PR TITLE
Move to uploading native JS website

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Build with Gradle
-        run: ./gradlew assembleJsBrowserProduction
+        run: ./gradlew jsBrowserDistribution
         working-directory: frontend
 
       - name: Move the built website to /public for upload

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,11 +53,11 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Build with Gradle
-        run: ./gradlew assemble
+        run: ./gradlew assembleJsBrowserProduction
         working-directory: frontend
 
       - name: Move the built website to /public for upload
-        run: mv ./composeApp/build/dist/wasmJs/productionExecutable ./public
+        run: mv ./composeApp/build/dist/js/productionExecutable ./public
         working-directory: frontend
 
       - name: Upload the website

--- a/frontend/composeApp/src/jsMain/resources/index.html
+++ b/frontend/composeApp/src/jsMain/resources/index.html
@@ -6,7 +6,7 @@
     <title>MTA Data Visualizer</title>
     <link type="text/css" rel="stylesheet" href="styles.css">
     <script src="skiko.js"></script>
-    <script type="application/javascript" src="composeApp.js"></script>
+    <script type="application/javascript" src="jsComposeApp.js"></script>
 </head>
 <body>
 </body>

--- a/frontend/composeApp/src/wasmJsMain/resources/index.html
+++ b/frontend/composeApp/src/wasmJsMain/resources/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MTA Data Visualizer</title>
     <link type="text/css" rel="stylesheet" href="styles.css">
-    <script type="application/javascript" src="composeApp.js"></script>
+    <script type="application/javascript" src="wasmJsComposeApp.js"></script>
 </head>
 <body>
 </body>


### PR DESCRIPTION
As discussed in #16, Safari doesn't currently support WASM fully for Kotlin Multiplatform so use native JS for compatibility instead.

Also fixes an error in the .html files for wasm and js due to a rename in #18.