### PR TITLE
Make station list mobile responsive

### DIFF
--- a/frontend/composeApp/src/commonMain/kotlin/com/duchastel/simon/mtadatavisualizer/ui/ridershipticker/RidershipTicker.kt
+++ b/frontend/composeApp/src/commonMain/kotlin/com/duchastel/simon/mtadatavisualizer/ui/ridershipticker/RidershipTicker.kt
@@ -11,6 +11,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.Button
@@ -146,18 +149,21 @@ private fun StationRidershipTicker(station: State.Station) {
             modifier = Modifier
                 .fillMaxWidth(fill)
                 .padding(horizontal = 32.dp, vertical = 8.dp),
-            horizontalArrangement = Arrangement.SpaceBetween
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
                 text = station.name,
                 fontSize = 24.sp,
-                fontWeight = FontWeight.Medium
+                fontWeight = FontWeight.Medium,
+                modifier = Modifier.weight(1f)
             )
-
+            Spacer(modifier = Modifier.width(32.dp))
             Text(
                 text = formatRidershipString(station.numRiders.toInt()),
                 fontSize = 24.sp,
-                fontWeight = FontWeight.Medium
+                fontWeight = FontWeight.Medium,
+                modifier = Modifier.wrapContentWidth()
             )
         }
     }


### PR DESCRIPTION
Long station names would cause the list to smoosh the ridership count, whereas now the ridership count is always preserved and the station name gets wrapped (which looks better).

## Screenshots

#### Before

----
| Before | After |
|---|---|
| ![image](https://github.com/user-attachments/assets/b32a6982-4119-47e6-9e47-9019de945d86) | ![image](https://github.com/user-attachments/assets/d4aea755-1a79-40f1-8ebf-2182eaa33b48) |
----

