### PR TITLE
Fix duplicate station names

### DIFF
--- a/backend/mtaSubwayStationSync.js
+++ b/backend/mtaSubwayStationSync.js
@@ -82,10 +82,11 @@ function groupStations(stations) {
     // Update station names if there are duplicates based on name
     stationsWithName.forEach(group => {
         if (canonicalNameCount[group.name] > 1) {
+            let routes = []
             group.data.forEach(station => {
-                const routes = station.routes.split(' ').join('/');
-                station.name = `${station.name} (${routes})`;
+                routes.push(...station.routes.split(' '));
             });
+            group.name = `${group.name} (${routes.join('/')})`;
         }
     });
 


### PR DESCRIPTION
When I de-duped station names in #17, I had a bug where I deduped the names at the station level but not the complex level (and the complex level is what's important). I modified the logic to 1) use all routes from sub-stations merged together, and 2) modify the top-level station name (which is what GET /today/stations uses), not the nested station names.

## Screenshots

See `34 St-Penn Station (1/2/3)` and `34 St-Penn Station (A/C/E)` below as an example:

![image](https://github.com/user-attachments/assets/1e553e28-6c0b-4135-ba7b-d4a700da6ca2)
